### PR TITLE
fix: stagger add-on WP job-card time windows to prevent OverlapError

### DIFF
--- a/shree_polymer_custom_app/shree_polymer_custom_app/doctype/add_on_work_planning/add_on_work_planning.py
+++ b/shree_polymer_custom_app/shree_polymer_custom_app/doctype/add_on_work_planning/add_on_work_planning.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import getdate,flt
+from frappe.utils import getdate,flt,add_to_date
 from frappe.utils.data import get_time, now
 
 class AddOnWorkPlanning(Document):
@@ -124,7 +124,8 @@ class AddOnWorkPlanning(Document):
 				frappe.throw("Value not found for no.of times to add qty in SPP Settings")
 			if not spp_settings.default_time:
 				frappe.throw("Value not found for default time in SPP Settings")
-			for item in doc_info.items:
+			base_time = now()
+			for time_offset, item in enumerate(doc_info.items):
 				# bom = list(filter(lambda x: x.get('item') == item.item,doc_info.bom_wt_item))[0].get('bom')
 				bom = frappe.db.sql(""" SELECT B.name,B.item FROM `tabBOM Item` BI INNER JOIN `tabBOM` B ON BI.parent = B.name WHERE  B.item=%(item_code)s AND B.is_default=1 AND B.is_active=1 """,{"item_code":item.item},as_dict=1)
 				actual_weight = flt(spp_settings.target_qty,3) * flt(list(filter(lambda x: x.get('item') == item.item,doc_info.qty_wt_item))[0].get('qty'),3)
@@ -151,7 +152,7 @@ class AddOnWorkPlanning(Document):
 				wo.planned_start_date = getdate(doc_info.date)
 				wo.docstatus = 1
 				wo.save(ignore_permissions=True)
-				jo_card = update_job_cards(wo.name,actual_weight,doc_info,item,wo.production_item)
+				jo_card = update_job_cards(wo.name,actual_weight,doc_info,item,wo.production_item,time_offset_mins=time_offset,base_time=base_time)
 				if not jo_card:
 					frappe.db.rollback()
 					return False
@@ -186,15 +187,19 @@ def validate_get_serial_no(self,type__,item = None,job_card = None):
 				return
 		no += 1
 
-def update_job_cards(wo,actual_weight,doc_info,item,production_mat_item):
+def update_job_cards(wo,actual_weight,doc_info,item,production_mat_item,time_offset_mins=0,base_time=None):
 	try:
 		job_cards = frappe.db.get_all("Job Card",filters={"work_order":wo})
 		lot_number = get_spp_batch_date(doc_info)
 		barcode = generate_barcode(lot_number)
+		_base = base_time or now()
+		_from = add_to_date(_base, minutes=time_offset_mins)
+		_to = add_to_date(_base, minutes=time_offset_mins + 1)
 		for job_card in job_cards:
 			jc = frappe.get_doc("Job Card",job_card.name)
 			jc.append("time_logs",{
-				"from_time":now(),
+				"from_time":_from,
+				"to_time":_to,
 				"completed_qty":flt(actual_weight,3),
 				"time_in_mins":1
 			})


### PR DESCRIPTION
## Problem
Multi-item **Add-On Work Planning** on the *same press* fails the legacy leg with:
`OverlapError: Row 1: From Time and To Time of PO-JOB<b> is overlapping with PO-JOB<a>`
followed by `DoesNotExistError: Add On Work Planning <name> not found`.

**Root cause:** `update_job_cards` stamped every job card's time log with a bare
`now()` and **no `to_time`**. When a plan has 2+ items on the **same workstation**,
ERPNext `validate_time_logs` sees the second card's window collide with the first
→ throws. That failure makes `create_work_order` issue a transaction-wide
`frappe.db.rollback()` which wipes the parent doc, so `on_submit_value`'s
`self.reload()` then raises `DoesNotExistError`.

It is **data-dependent (multi-item, same press), not path-dependent** — the same
code runs whether the doc is created directly in the legacy UI or via the sync
bridge. Different presses never collide (overlap query filters by workstation).

> Note: this only manifests where ERPNext realizes the first card's
> `to_time` (= `from + 1 min`); on sites that leave time-log `to_time` NULL the
> overlap SQL yields no rows and the throw is silently avoided.

## Fix
Give each item's job card an explicit, non-overlapping window:
- `from = base_time + n minutes`, `to = from + 1 minute` (n = item index)
- Adjacent boundaries don't overlap (ERPNext uses a strict `>`)
- A real `to_time` makes `total_time_in_mins > 0`, so the card is also excluded
  from the scheduled-time overlap query

~10 lines; behavior-preserving for the non-colliding cases.

## Test plan (verified on spp15.local, real master data, all runs rolled back)
- [x] **RED**: 2 items on P15 → `OverlapError` (matches live `ADWRKP-05786`)
- [x] **GREEN**: 2 items on P15 → submits; staggered non-overlapping windows; both job cards linked
- [x] Regression: single-item unaffected
- [x] Regression: 2 items / different workstation unaffected (orig `ADWRKP-05937` config)
- [x] `py_compile` clean
- [ ] Live verify on sppmaster after deploy

## Scope
Change A only (the `OverlapError` root cause). A separate failure in
`create_work_order` (e.g. missing BOM) can still hit the destructive
`frappe.db.rollback()` that wipes the parent — that's **Change B**, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)