### PR TITLE
fix(mpe): reset compound_available_qty before recompute — fixes halved compound consumption on bridge MPEs

### DIFF
--- a/shree_polymer_custom_app/shree_polymer_custom_app/doctype/moulding_production_entry/moulding_production_entry.py
+++ b/shree_polymer_custom_app/shree_polymer_custom_app/doctype/moulding_production_entry/moulding_production_entry.py
@@ -166,6 +166,15 @@ class MouldingProductionEntry(Document):
     def cmpr_balbin_get_cmp_qty(self):
         import json
         self.updated_batch_details = json.loads(self.batch_details)
+        # Reset before recomputing so this is idempotent across multiple validate
+        # passes. validate() runs on both insert and submit; when a caller does
+        # doc.insert() then doc.submit() on the SAME in-memory object (the bridge
+        # does exactly this), the un-reset "+=" accumulated compound_available_qty
+        # twice (e.g. 0.9 -> 1.8), which then HALVED the recomputed consumed qty in
+        # validate_comsumption_details (live: MLDPE-32460 consumed 0.255 vs the
+        # 0.51 Console sent). The native form submits via two separate requests so
+        # it never doubled and never surfaced this. Reset makes it correct for both.
+        self.compound_available_qty = 0
         for is__bc in self.updated_batch_details:
             if is__bc.get('is_balance_bin'):
                 self.compound_available_qty += is__bc.get('consumed__qty')


### PR DESCRIPTION
## The discrepancy (MLDPE-32460)
The MPE's Manufacture Stock Entry (`MPE-2026-05314`) **consumed only 0.255 Kg** of compound while **producing 0.51 Kg** — a physically impossible >100% yield. Console sent `consumed__qty = 0.51` (correct, matching the 0.51 produced); the legacy MPE **halved** it to 0.255.

Native MPEs are fine (e.g. MLDPE-32434: consumed 11.813 ≈ produced 11.774).

## Root cause
`cmpr_balbin_get_cmp_qty` accumulates `self.compound_available_qty` with `+=` but **never resets it to 0** first:
```python
def cmpr_balbin_get_cmp_qty(self):
    self.updated_batch_details = json.loads(self.batch_details)
    for is__bc in self.updated_batch_details:
        ...
        self.compound_available_qty += is__bc.get('qty')   # never reset
```
`validate()` runs on **both insert and submit**. The legacy bridge does `doc.insert()` then `doc.submit()` on the **same in-memory object** (`sync_api.py`: insert @668, submit @716), so the two validate passes accumulate the bin qty twice: **0.9 → 1.8**.

`validate_comsumption_details` then computes the fresh-bin share as `(bin_qty / compound_available_qty) * weight = (0.9 / 1.8) * 0.51 = 0.255` — exactly the halved value stored.

The native form submits via **two separate HTTP requests** (a fresh doc object each), so `compound_available_qty` never carried over — which is why this never surfaced natively.

## Fix
Reset `self.compound_available_qty = 0` at the top of `cmpr_balbin_get_cmp_qty`, making the recompute idempotent regardless of how many validate passes run.

## Verified on spp15.local (local bench)
| | before reset | after reset |
|---|---|---|
| 1st validate pass | 0.9 | 0.9 |
| 2nd validate pass | **1.8** ❌ | **0.9** ✅ |

Native behaviour unchanged (reset + 0.9 = 0.9). Downstream: `(0.9/0.9)*0.51 = 0.51` → consumed matches Console.

## Test plan
- [ ] Bridge MPE (insert+submit same object) → SE consumes qty ≈ produced weight (not halved)
- [ ] Native MPE via form → unchanged
- [ ] Multi-bin MPE → compound_available_qty = sum of bin qtys once, not doubled