### PR TITLE
fix(deflash-receipt): log real traceback before rollback throws (un-swallow)

### DIFF
--- a/shree_polymer_custom_app/shree_polymer_custom_app/doctype/deflashing_receipt_entry/deflashing_receipt_entry.py
+++ b/shree_polymer_custom_app/shree_polymer_custom_app/doctype/deflashing_receipt_entry/deflashing_receipt_entry.py
@@ -242,8 +242,14 @@ class DeflashingReceiptEntry(Document):
 				submit_inspection_entry(self,exe__stentry,spp_settings.scrap_warehouse)
 				update_dc_status(self)
 			except Exception:
-				manual_rollback_entries(self,"Something went wrong not able to submit stock entries..!")
+				# Log the REAL traceback FIRST. manual_rollback_entries() ends in
+				# frappe.throw(), so it never returns — with the log_error after it
+				# (as before), the actual failure inside the try was never recorded,
+				# leaving only the generic "Deflashing Receipt Entry Stock submission
+				# failed..!" surfaced to the bridge/Console. That masked a persistent
+				# Incoming-Inspection legacy failure whose root cause was invisible.
 				frappe.log_error(title="Deflashing Receipt Entry stock submission failed",message=frappe.get_traceback())
+				manual_rollback_entries(self,"Something went wrong not able to submit stock entries..!")
 		else:
 			frappe.throw("Stock Entry Reference not found in <b>Deflashing Receipt Entry</b>")
 


### PR DESCRIPTION
## Problem (issue #4 in the batch: Incoming Inspection → Legacy fail)

Incoming Inspection fails on the Legacy leg with **"Deflashing Receipt Entry Stock submission failed..!"** — persistently, since at least **2026-07-07**. The real cause has been undiagnosable because it's masked by three layers of catch-and-rethrow:

1. `inspection_entry.submit_deflash_receipt_entry` catches → throws "Deflashing Receipt Entry Stock submission failed..!"
2. `deflashing_receipt_entry.manual_on_submit` catches → calls `manual_rollback_entries()` → throws "Something went wrong not able to submit stock entries..!"
3. The innermost `frappe.log_error()` that would record the **actual** failure is **dead code**:

```python
except Exception:
    manual_rollback_entries(self, "Something went wrong...")   # ends in frappe.throw() — never returns
    frappe.log_error(..., message=frappe.get_traceback())      # UNREACHABLE
```

So the actual failure inside the `try` (the stock-entry submit / `submit_inspection_entry` — likely a negative-stock or batch-resolution error in the deflashing vendor warehouse) was **never logged anywhere**.

## Fix

Reorder so `frappe.log_error()` runs **before** `manual_rollback_entries()` throws. Purely diagnostic — no change to the rollback behaviour — but the next occurrence will finally record the true traceback under title *"Deflashing Receipt Entry stock submission failed"*, so the root cause can actually be fixed.

## Why no test
A 2-line reorder that turns dead code live; exercising it needs the full legacy stack plus a failing Deflashing Receipt Entry. The correctness is self-evident from the control flow (throw-before-log → log-before-throw).

## Next step
Deploy, let the failure recur once, then read the now-populated legacy Error Log to get the real cause and fix it.