### PR TITLE
fix(mpe): drop is_scrap_item from purge consume row (erpnext >= 15.116)

### DIFF
--- a/shree_polymer_custom_app/shree_polymer_custom_app/doctype/moulding_production_entry/moulding_production_entry.py
+++ b/shree_polymer_custom_app/shree_polymer_custom_app/doctype/moulding_production_entry/moulding_production_entry.py
@@ -1115,12 +1115,18 @@ def append_source_details(stock_entry, self, work_order):
         stock_entry.append("items", {
             "item_code": self.compound,  # Same compound item
             "s_warehouse": work_order.source_warehouse,
-            "t_warehouse": None,  # Consumed as scrap (not transferred) - avoids batch bundle issues
+            # Consumed as scrap (not transferred). NOTE: is_scrap_item must stay 0 —
+            # erpnext >= 15.116 (validate_warehouse) treats Manufacture rows with
+            # is_scrap_item=1 as OUTPUTS: it blanks s_warehouse and demands a
+            # t_warehouse ("Target warehouse is mandatory for row N"), which both
+            # fails this insert and would invert the movement (purge arriving in a
+            # warehouse instead of leaving the source). Purge IS consumption —
+            # keep it a plain consume row (same net stock effect as before).
+            "t_warehouse": None,
             "stock_uom": "Kg",
             "uom": "Kg",
             "conversion_factor_uom": 1,
             "is_finished_item": 0,
-            "is_scrap_item": 1,  # Mark as scrap/waste material for tracking
             "transfer_qty": flt(total_purge_qty, 3),
             "qty": flt(total_purge_qty, 3),
             "use_serial_batch_fields": 1,  # Use batch fields for consumption items


### PR DESCRIPTION
## Summary

Every MPE with purge/leakage > 0 now fails on sppmaster with **"Target warehouse is mandatory for row 2"** — native screen and bridge alike. Live: MLDPE-32895 (lot 26G18X02) stuck at docstatus=0.

## Root cause — ERPNext version behavior change, not our code

sppmaster was upgraded to **erpnext 15.116.0**. Its `validate_warehouse` now treats any Manufacture row with `is_scrap_item=1` as an **output**: it force-blanks `s_warehouse` and requires a `t_warehouse` — unconditionally:

```python
if self.purpose in ["Manufacture", "Repack"]:
    if d.is_finished_item or d.is_scrap_item:
        d.s_warehouse = None
        if not d.t_warehouse:
            frappe.throw(_("Target warehouse is mandatory for row {0}"))
```

Older erpnext gated this on `has_bom` (an item row carrying `bom_no`) — never true for our SEs — so the purge row with `t_warehouse=None` passed. That's why:
- production (older erpnext) still works with identical code
- native purge MPEs on sppmaster worked until Jul 14, then the erpnext upgrade landed
- since the upgrade, purge is effectively broken on sppmaster (purge is **mandatory** on injection presses via `is_injection_moulding`)

## Fix

Remove `is_scrap_item: 1` from the purge line — it becomes a plain consumption row (consume purge qty from `work_order.source_warehouse`). This is the **identical net stock movement** to pre-upgrade behavior.

Why not set `t_warehouse` instead: under 15.116 semantics that would make the purge **arrive** in the scrap warehouse without ever leaving the source — inverting the movement and breaking the mass balance the MPE frontend itself displays (`consumption = production + scrap − shell`).

Checked: no report or query anywhere in the app reads `is_scrap_item` to identify purge rows (only other use is DRE's scrap line, which sets a `t_warehouse` and is unaffected).

## Test plan

- [ ] Bridge MPE with purge > 0 on sppmaster → SE inserts and submits; consume rows = normal + purge, FG row unchanged
- [ ] Native screen MPE with purge > 0 → same
- [ ] MPE without purge → unchanged (row not appended)
- [ ] Retry MLDPE-32895 (lot 26G18X02) after deploy