### PR TITLE
fix(report): populate per-row Sheeting Req in Blanking And Sheeting print

### DIFF
--- a/shree_polymer_custom_app/shree_polymer_custom_app/report/blanking_and_sheeting_requirement/blanking_and_sheeting_requirement.py
+++ b/shree_polymer_custom_app/shree_polymer_custom_app/report/blanking_and_sheeting_requirement/blanking_and_sheeting_requirement.py
@@ -209,6 +209,7 @@ def get_print_html(filters=None):
 		if current is None or current["compound_ref"] != compound:
 			current = {"compound_ref": compound, "rows": [], "subtotal": 0.0}
 			groups.append(current)
+		row["sheeting_req_kgs"] = flt(flt(row.get("blanking_req_kgs") or 0) * ratio, 3)
 		current["rows"].append(row)
 		current["subtotal"] += flt(row.get("blanking_req_kgs") or 0)
 


### PR DESCRIPTION
## Problem

The printed **Blanking And Sheeting Requirement** report shows `0.000` in the **Sheeting Req (Kg)** column on every data row. The per-compound subtotals and the grand total are correct — only the rows are blank.

The on-screen query report is unaffected and shows the correct per-row values.

## Cause

`get_print_html` builds the compound groups and accumulates the blanking subtotal, but never assigns `sheeting_req_kgs` onto the individual rows. The print template renders `{{ "%.3f"|format(row.sheeting_req_kgs or 0) }}`, so it falls through to `0.000`.

`get_grouped_data` (the on-screen path) does assign it, which is why only the print output is wrong.

This is **not** a deploy lag. `f076998` ("Sheeting Req = Blanking × 1.30") only corrected `_summary_ratio()` and the subtotal / grand-total paths, so the row-level gap survived it. The bug is present at the current `Bin-issue-roleback` tip (`b782ef5`), which is what production runs.

## Fix

One line — assign the same value the on-screen path computes, using the same `ratio`:

```python
row["sheeting_req_kgs"] = flt(flt(row.get("blanking_req_kgs") or 0) * ratio, 3)
```

Subtotals and grand total are untouched.

## Verification

Rendered the actual print HTML on `spp15.local` for **08-04-2026** (all shifts), before and after:

| | Before | After |
|---|---|---|
| Data rows with `0.000` sheeting | 47 of 47 | **0 of 47** |

Rows now match the on-screen report exactly:

```
P1  : TUNGYU - 100 Ton   14.872 | 19.333
P15 : TUNGYU - 150 Ton   15.649 | 20.344
P11 : TUNGYU - 150 Ton   37.296 | 48.485
P10 : TUNGYU - 150 Ton   13.680 | 17.784
P16 : TUNGYU - 150 Ton   14.760 | 19.188
```

Subtotals unchanged: C_4910 39.677, C_55EC01 145.454, C_60103 96.174, C_6122 109.506, C_69221 66.146, C_70103 71.885.

## Notes

Reported from the shop floor — a supervisor hand-calculated the sheeting column on a printout because the figures were missing.