### PR TITLE
feat(report): order Blanking And Sheeting by press, keep compound totals

### DIFF
--- a/shree_polymer_custom_app/shree_polymer_custom_app/report/blanking_and_sheeting_requirement/blanking_and_sheeting_requirement.html
+++ b/shree_polymer_custom_app/shree_polymer_custom_app/report/blanking_and_sheeting_requirement/blanking_and_sheeting_requirement.html
@@ -46,6 +46,8 @@
 		border-top: 2px solid #000;
 	}
 	tr.group { page-break-inside: avoid; }
+	h2.summary-title { font-size: 13px; margin: 16px 0 6px; }
+	table.data.summary { width: 60%; page-break-inside: avoid; }
 	.footer { margin-top: 10px; font-size: 10px; color: #555; text-align: right; }
 </style>
 </head>
@@ -77,7 +79,7 @@
 			<th>Date</th>
 			<th>Shift</th>
 			<th>Work Plan ID</th>
-			<th>Press No</th>
+			<th>Compound Ref</th>
 			<th>Product Ref</th>
 			<th>Mould No</th>
 			<th>Blank Type</th>
@@ -95,14 +97,14 @@
 
 		{% for g in groups %}
 		<tr class="group-head">
-			<td colspan="12">Compound: {{ g.compound_ref }}</td>
+			<td colspan="12">Press: {{ g.press_no }}</td>
 		</tr>
 		{% for row in g.rows %}
 		<tr class="group">
 			<td>{{ frappe.format(row.date, {"fieldtype": "Date"}) if row.date else "" }}</td>
 			<td>{{ row.shift or "" }}</td>
 			<td>{{ row.id or "" }}</td>
-			<td>{{ row.press_no or "" }}</td>
+			<td>{{ row.compound_ref or "" }}</td>
 			<td>{{ row.product_ref or "" }}</td>
 			<td>{{ row.mould_no or "" }}</td>
 			<td>{{ row.blank_type or "" }}</td>
@@ -114,7 +116,7 @@
 		</tr>
 		{% endfor %}
 		<tr class="subtotal">
-			<td colspan="10" style="text-align:right;">Subtotal — {{ g.compound_ref }}</td>
+			<td colspan="10" style="text-align:right;">Subtotal — {{ g.press_no }}</td>
 			<td class="num">{{ "%.3f"|format(g.subtotal or 0) }}</td>
 			<td class="num">{{ "%.3f"|format(g.sheeting_subtotal or 0) }}</td>
 		</tr>
@@ -129,6 +131,33 @@
 		{% endif %}
 	</tbody>
 </table>
+
+{% if compound_summary %}
+<h2 class="summary-title">Compound Summary</h2>
+<table class="data summary">
+	<thead>
+		<tr>
+			<th>Compound Ref</th>
+			<th>Blanking Req (Kg)</th>
+			<th>Sheeting Req (Kg)</th>
+		</tr>
+	</thead>
+	<tbody>
+		{% for c in compound_summary %}
+		<tr>
+			<td>{{ c.compound_ref }}</td>
+			<td class="num">{{ "%.3f"|format(c.blanking_req_kgs or 0) }}</td>
+			<td class="num">{{ "%.3f"|format(c.sheeting_req_kgs or 0) }}</td>
+		</tr>
+		{% endfor %}
+		<tr class="grand-total">
+			<td style="text-align:right;">Grand Total</td>
+			<td class="num">{{ "%.3f"|format(grand_total or 0) }}</td>
+			<td class="num">{{ "%.3f"|format(sheeting_grand_total or 0) }}</td>
+		</tr>
+	</tbody>
+</table>
+{% endif %}
 
 <div class="footer">Printed on: {{ frappe.format(printed_on, {"fieldtype": "Date"}) }}</div>
 

--- a/shree_polymer_custom_app/shree_polymer_custom_app/report/blanking_and_sheeting_requirement/blanking_and_sheeting_requirement.py
+++ b/shree_polymer_custom_app/shree_polymer_custom_app/report/blanking_and_sheeting_requirement/blanking_and_sheeting_requirement.py
@@ -32,6 +32,16 @@ def get_columns():
 	]
 
 
+# Presses are stored as free text ("P1 : TUNGYU - 100 Ton"), so a plain sort gives
+# P1, P10, P11, P2 ... Order on the digits after the P instead, and park any
+# non-numeric station (e.g. "Dot Marker") after the numbered presses.
+PRESS_ORDER_SQL = """
+		CASE WHEN press_no REGEXP '^P[0-9]+' THEN 0 ELSE 1 END,
+		CAST(REGEXP_SUBSTR(press_no, '[0-9]+') AS UNSIGNED),
+		press_no
+"""
+
+
 def _build_query(filters):
 	condition = ""
 	acondition = ""
@@ -133,7 +143,7 @@ def _build_query(filters):
 					AND AWPIT.shift_type = AWP.shift_time
 			WHERE AWP.docstatus = 1 {acondition}
 		) combined
-		ORDER BY compound_ref, date, shift, press_no
+		ORDER BY {PRESS_ORDER_SQL}, compound_ref, date, shift
 	"""
 
 
@@ -141,44 +151,67 @@ def get_raw_rows(filters):
 	return frappe.db.sql(_build_query(filters), as_dict=1)
 
 
+def _group_by_press(raw, ratio):
+	"""Split the rows into press blocks, in the natural press order the query
+	already applied, and annotate every row with its sheeting requirement."""
+	groups = []
+	current = None
+
+	for row in raw:
+		row["sheeting_req_kgs"] = flt(flt(row.get("blanking_req_kgs") or 0) * ratio, 3)
+		press = row.get("press_no")
+		if current is None or current["press_no"] != press:
+			current = {"press_no": press, "rows": [], "subtotal": 0.0}
+			groups.append(current)
+		current["rows"].append(row)
+		current["subtotal"] += flt(row.get("blanking_req_kgs") or 0)
+
+	# Subtotals stay at full precision so the grand total is the sum of the raw
+	# values, not of pre-rounded ones; callers round for display.
+	for g in groups:
+		g["sheeting_subtotal"] = g["subtotal"] * ratio
+
+	return groups
+
+
+def _compound_summary(raw, ratio):
+	"""Per-compound totals across every press. The table itself runs press by
+	press for the shop floor, so this keeps the mixing room's compound
+	quantities available in one place."""
+	totals = {}
+	for row in raw:
+		compound = row.get("compound_ref")
+		totals[compound] = totals.get(compound, 0.0) + flt(row.get("blanking_req_kgs") or 0)
+
+	return [
+		{
+			"compound_ref": compound,
+			"blanking_req_kgs": flt(total, 3),
+			"sheeting_req_kgs": flt(total * ratio, 3),
+		}
+		for compound, total in sorted(totals.items())
+	]
+
+
 def get_grouped_data(filters):
 	raw = get_raw_rows(filters)
 	ratio = _summary_ratio()
 	out = []
-	current_compound = None
-	subtotal = 0.0
 
-	def emit_subtotal(label):
+	for g in _group_by_press(raw, ratio):
+		out.extend(g["rows"])
 		out.append({
-			"date": None,
-			"shift": None,
-			"id": None,
-			"press_no": None,
-			"product_ref": None,
-			"mould_no": None,
-			"compound_ref": f"Total — {label}",
-			"blank_type": None,
-			"avg_blank_wt_kgs": None,
-			"avg_lift_wt_kgs": None,
-			"target_lifts": None,
-			"blanking_req_kgs": flt(subtotal, 3),
-			"sheeting_req_kgs": flt(subtotal * ratio, 3),
+			"press_no": f"Total — {g['press_no']}",
+			"blanking_req_kgs": flt(g["subtotal"], 3),
+			"sheeting_req_kgs": flt(g["sheeting_subtotal"], 3),
 		})
 
-	for row in raw:
-		compound = row.get("compound_ref")
-		if current_compound is None:
-			current_compound = compound
-		if compound != current_compound:
-			emit_subtotal(current_compound)
-			current_compound = compound
-			subtotal = 0.0
-		row["sheeting_req_kgs"] = flt(flt(row.get("blanking_req_kgs") or 0) * ratio, 3)
-		out.append(row)
-		subtotal += flt(row.get("blanking_req_kgs") or 0)
-
-	if current_compound is not None:
-		emit_subtotal(current_compound)
+	for c in _compound_summary(raw, ratio):
+		out.append({
+			"compound_ref": f"Compound Total — {c['compound_ref']}",
+			"blanking_req_kgs": c["blanking_req_kgs"],
+			"sheeting_req_kgs": c["sheeting_req_kgs"],
+		})
 
 	return out
 
@@ -202,19 +235,8 @@ def get_print_html(filters=None):
 	raw = get_raw_rows(filters)
 	ratio = _summary_ratio()
 
-	groups = []
-	current = None
-	for row in raw:
-		compound = row.get("compound_ref")
-		if current is None or current["compound_ref"] != compound:
-			current = {"compound_ref": compound, "rows": [], "subtotal": 0.0}
-			groups.append(current)
-		row["sheeting_req_kgs"] = flt(flt(row.get("blanking_req_kgs") or 0) * ratio, 3)
-		current["rows"].append(row)
-		current["subtotal"] += flt(row.get("blanking_req_kgs") or 0)
-
-	for g in groups:
-		g["sheeting_subtotal"] = flt(g["subtotal"] * ratio, 3)
+	groups = _group_by_press(raw, ratio)
+	compound_summary = _compound_summary(raw, ratio)
 
 	grand_total = sum(g["subtotal"] for g in groups)
 	sheeting_grand_total = flt(grand_total * ratio, 3)
@@ -237,6 +259,7 @@ def get_print_html(filters=None):
 			"letter_head": letter_head_content,
 			"filters": filters,
 			"groups": groups,
+			"compound_summary": compound_summary,
 			"grand_total": flt(grand_total, 3),
 			"sheeting_grand_total": sheeting_grand_total,
 			"printed_on": nowdate(),


### PR DESCRIPTION
Shop floor asked for the **Blanking And Sheeting Requirement** report to run press by press starting at P1.

Base is `Bin-issue-roleback` (retargeted after #8 merged). Single commit.

## Sort

Presses are free text (`P1 : TUNGYU - 100 Ton`), so `ORDER BY press_no` sorted lexically:

```
P1, P10, P11, P12, P14, P15, P16, P17, P18, P19, P2, P20, P21, P22, P3, P4, ...
```

Now ordered on the digits after the `P`, with any non-numeric station (`Dot Marker`) parked after the numbered presses:

```
P1, P2, P3, P4, P5, P6, P9, P10, P11, P12, P14, P15, P16, P17, P18, P19, P20, P22
```

## Layout

- Table groups by **Press** with a per-press subtotal.
- **Compound Ref** moves from the group header into a column (replaces the now-redundant Press No column, so the print stays at 12 columns).
- The per-compound quantities the mixing room works from are retained as a **Compound Summary** section after the main table — nothing is lost.

## Refactor

Grouping is now shared between the on-screen report and the print via `_group_by_press` / `_compound_summary`, so the two can no longer drift apart — which is how the blank-print bug in #8 happened in the first place.

Press subtotals are held at full precision and rounded only for display, so the grand total is the sum of the raw rows rather than of pre-rounded subtotals.

## Verification

Run on `spp15.local` for **08-04-2026**, 47 rows:

| Check | Result |
|---|---|
| Press order | P1, P2, P3, P4, P5, P6, P9, P10 … P22 |
| Press blocks | 18, each press contiguous |
| Grand total vs raw row total | 842.421 == 842.421 |
| Compound Summary vs previous compound subtotals | identical, all 18 |
| Data rows with blank Sheeting Req | 0 of 47 |

Compound Summary reproduces the current report exactly:

```
C_4910   30.521 / 39.677      C_55EC01 111.888 / 145.454
C_60103  73.980 / 96.174      C_6122    84.235 / 109.506
C_69221  50.881 / 66.146      C_70103   55.296 / 71.885
C_70104  60.491 / 78.638      C_70EP02  17.107 / 22.239
```

## Note for review

Press No no longer repeats on every row (it is the block header). If a page break splits a press block, the press name won't be on the continuation rows. Easy to add back as a column if the floor prefers it.