### PR TITLE
fix(bin movement): self.docname masked every real failure

### DIFF
--- a/shree_polymer_custom_app/shree_polymer_custom_app/doctype/bin_movement/bin_movement.py
+++ b/shree_polymer_custom_app/shree_polymer_custom_app/doctype/bin_movement/bin_movement.py
@@ -23,11 +23,20 @@ def make_bin_release_movement(self):
 				frappe.db.set_value("Item Bin Mapping",bin__.ibm_id,"is_retired",1)
 				frappe.db.sql(""" UPDATE `tabBlank Bin Issue Item` set is_completed = 1 where bin=%(bin)s and is_completed=0 """,{"bin":bin__.bin_id})
 				frappe.db.commit()
-	except Exception:
+	except Exception as e:
 		frappe.log_error(title="make_bin_release_movement failed",message=frappe.get_traceback())
-		frappe.get_doc(self.doctype,self.docname).db_set("docstatus", 0)
+		# self.docname does not exist on a Document - it is self.name. This line
+		# raised AttributeError inside the handler, so EVERY failure here was
+		# reported to the operator as
+		#     'BinMovement' object has no attribute 'docname'
+		# and the real cause (e.g. "Asset BLB -00039 does not belong to the
+		# location U2 - Ambattur") was only ever visible in the Error Log.
+		frappe.get_doc(self.doctype,self.name).db_set("docstatus", 0)
 		frappe.db.commit()
 		self.reload()
+		# Re-raise the real reason. Swallowing it left the entry silently reset
+		# to draft while the operator was told nothing useful.
+		frappe.throw(str(e))
 
 def make_asset_movement(spp_settings,x):
 	asset__mov = frappe.new_doc("Asset Movement")


### PR DESCRIPTION
Live on production — ref `1787040774927`, and 5 more today.

## The reported error is not the failure

```
'BinMovement' object has no attribute 'docname'
```

That is the **error handler crashing**, not the error.

`make_bin_release_movement` wraps its work in `try/except`. On failure it logs the traceback, then resets the entry to draft:

```python
frappe.get_doc(self.doctype, self.docname).db_set("docstatus", 0)
```

A Frappe `Document` has `self.name`, not `self.docname`. So the handler raised `AttributeError` and replaced the real reason with a meaningless one.

## The real reason

Recovered from the legacy Error Log, same second:

```
ValidationError: Asset BLB -00039 does not belong to the location U2 - Ambattur
```

`make_asset_movement` transfers the bin from `SPP Settings.to_location`, and ERPNext validates the asset is actually at that source. The bin is not where settings say it is.

**That is something the operator could have acted on, and they were never shown it.**

## Changes

1. `self.docname` → `self.name`, so the handler stops crashing.
2. **Re-raise the real message.** The `except` previously swallowed it, leaving the entry silently reset to draft with no explanation — the same silent-failure pattern behind this week's partial ledgers.

After this, the operator sees the asset/location mismatch instead of an `AttributeError`.

## Not addressed here

The underlying data problem — bins not at the location `SPP Settings` expects — is separate. This PR makes it visible; it does not fix it. Expect Bin Movement to keep failing until the bin locations are corrected, but now with a message that says why.
