### PR TITLE
fix(mpe): tolerate a consumption row that carries no bin

### DIFF
--- a/shree_polymer_custom_app/shree_polymer_custom_app/doctype/moulding_production_entry/moulding_production_entry.py
+++ b/shree_polymer_custom_app/shree_polymer_custom_app/doctype/moulding_production_entry/moulding_production_entry.py
@@ -1036,6 +1036,20 @@ def submit_inspection_stock_entries_from_moulding(self, moulding_stock_entry):
 
 def update_bins(self, resp__s, spp_settings):
     for c__bin in resp__s:
+        # A consumption row with no bin is compound booked directly against its
+        # batch, not compound carried in a physical blank bin. Operators used to
+        # express this by raising a throwaway "dummy" Blanking DC + Blank Bin
+        # Issue purely so the shortfall had a bin to sit in; the qty is now
+        # booked against the batch itself, so no bin travels with it.
+        #
+        # Everything below this loop body assumes a bin exists: the two UPDATEs
+        # key on item_bin_mapping_name / blank_bin_issue_item_name (both absent
+        # here, so they match nothing), and the branch then falls through to
+        # make_asset_movement() for asset `None` — which raises while trying to
+        # move a trolley that does not exist. Skip: there is no bin to release
+        # and no asset to send back to blanking.
+        if not c__bin.get('bin'):
+            continue
         if c__bin.get('is__consumed') and c__bin.get('is_balance_bin'):
             frappe.db.sql(
                 f""" UPDATE `tabBlank Bin Issue Item` set is_completed=1 where name = '{c__bin.get('blank_bin_issue_item_name')}' """)

--- a/shree_polymer_custom_app/shree_polymer_custom_app/doctype/moulding_production_entry/test_moulding_production_entry.py
+++ b/shree_polymer_custom_app/shree_polymer_custom_app/doctype/moulding_production_entry/test_moulding_production_entry.py
@@ -46,6 +46,76 @@ class TestMouldingProductionEntryOnSubmit(unittest.TestCase):
 
             mock_rollback.assert_called_once()
 
+class TestUpdateBinsBinlessRows(unittest.TestCase):
+    """update_bins() must tolerate a consumption row that carries no bin.
+
+    Compound booked directly against its batch (rather than carried in a
+    physical blank bin) has no bin, no Item Bin Mapping and no Blank Bin Issue
+    Item. Before the guard, such a row fell into the consumed/not-balance
+    branch, whose two UPDATEs matched nothing and which then called
+    make_asset_movement() for asset `None` — moving a trolley that does not
+    exist. Nothing to release, nothing to move: the row must be skipped.
+    """
+
+    def _spp_settings(self):
+        settings = MagicMock()
+        settings.from_location = "Blanking"
+        return settings
+
+    def test_binless_consumed_row_is_skipped_entirely(self):
+        binless = {
+            "is__consumed": 1,
+            "is_balance_bin": 0,
+            "spp_batch_number": "26G27X24-1",
+            "batch_no__": "C_6023/26/08/08/013",
+            "consumed__qty": 1.445,
+            # no "bin", no item_bin_mapping_name, no blank_bin_issue_item_name
+        }
+
+        with patch.object(mpe_module, "frappe") as mock_frappe, \
+             patch.object(mpe_module, "make_asset_movement") as mock_move:
+            mock_frappe.db.sql.return_value = []
+            mpe_module.update_bins(MagicMock(), [binless], self._spp_settings())
+
+        mock_move.assert_not_called()
+        mock_frappe.db.sql.assert_not_called()
+
+    def test_normal_bin_row_still_releases_and_moves(self):
+        with_bin = {
+            "is__consumed": 1,
+            "is_balance_bin": 0,
+            "bin": "BLB -00138",
+            "item_bin_mapping_name": "IBM-001",
+            "blank_bin_issue_item_name": "BBII-001",
+            "job_card": "PO-JOB100044",
+        }
+
+        # last_mov empty -> the bin is not at from_location, so it must travel back
+        with patch.object(mpe_module, "frappe") as mock_frappe, \
+             patch.object(mpe_module, "make_asset_movement") as mock_move:
+            mock_frappe.db.sql.return_value = []
+            mpe_module.update_bins(MagicMock(), [with_bin], self._spp_settings())
+
+        mock_move.assert_called_once()
+        self.assertTrue(mock_frappe.db.sql.called)
+
+    def test_mixed_rows_only_the_binless_one_is_skipped(self):
+        rows = [
+            {"is__consumed": 1, "is_balance_bin": 0, "bin": "BLB -00138",
+             "item_bin_mapping_name": "IBM-001",
+             "blank_bin_issue_item_name": "BBII-001"},
+            {"is__consumed": 1, "is_balance_bin": 0, "spp_batch_number": "26G27X24-1"},
+        ]
+
+        with patch.object(mpe_module, "frappe") as mock_frappe, \
+             patch.object(mpe_module, "make_asset_movement") as mock_move:
+            mock_frappe.db.sql.return_value = []
+            mpe_module.update_bins(MagicMock(), rows, self._spp_settings())
+
+        # exactly one asset movement: the real bin's, never the bin-less row's
+        self.assertEqual(mock_move.call_count, 1)
+
+
 class TestMouldingProductionEntry(unittest.TestCase):
 	"""
 	Test cases for Moulding Production Entry - NEW FLOW (Single-Stage Submission)


### PR DESCRIPTION
## Why

`update_bins()` assumes every consumed row came from a physical blank bin. A row booked directly against its **batch** has none, so it fell into the consumed/not-balance branch where:

- both UPDATEs matched nothing (no `item_bin_mapping_name`, no `blank_bin_issue_item_name`)
- the branch then called `make_asset_movement()` for asset `None` — moving a trolley that does not exist

## What

Skip rows with no `bin`. There is nothing to release and no asset to send back to blanking.

## Context

This unblocks booking a compound shortfall against the batch itself, replacing the floor workaround: a throwaway Blanking DC + Blank Bin Issue raised purely so the missing kilos had a bin to sit in.

That workaround cannot book *just* the shortfall — measured on this database, `MLDPE-12500` re-issued a whole **11.320 Kg** bin to close a **1.119 Kg** gap, so the system believes 22.64 Kg was issued to a lot that physically consumed ~12.4 Kg. There are 894 provable cases (same bin + same batch issued twice to one job card), 235 of which were needed to clear a shortfall.

## Deploy order

**This must land BEFORE the Console side** (shree_polymer_console `feat/mpe-auto-topup-from-batch-balance`). It is a no-op until Console starts sending bin-less rows, so it is safe to deploy on its own.

## Test plan

- [x] `test_binless_consumed_row_is_skipped_entirely` — no Asset Movement, no SQL, no throw
- [x] `test_normal_bin_row_still_releases_and_moves` — regression guard, existing behaviour intact
- [x] `test_mixed_rows_only_the_binless_one_is_skipped` — exactly one asset movement
- [x] RED→GREEN proven: with the guard reverted, the two bin-less tests fail on `make_asset_movement` being called for asset `None`
- [x] Full module run matches the pre-change baseline (1 pre-existing error, unrelated — that test needs a site context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)